### PR TITLE
Update access permissions on the created user config file and directory

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ const MAX_NAME_COL_LEN = 30
 
 // Names for config dir and file - stored in the os.UserConfigDir() directory
 const CONFIG_FILE_DIR = "ivcap-cli"
-const CONFIG_FILE_NAME = ".ivcap-cli"
+const CONFIG_FILE_NAME = "config.yaml"
 
 // flags
 var (


### PR DESCRIPTION
This now uses:
755 for the config directory - read/write/execute access for the user and
                               read/execute for group + others
600 for the config file itself - read/write for the user and no access for
                                 groups + others

This fixes an issue on linux whereby the config file could not be created due to not having the execute bit set on the directory (preventing any access).