### PR TITLE
Bug/context get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,27 @@
 
 GIT_COMMIT := $(shell git rev-list --abbrev-commit --tags --max-count=1)
-BUILD_DATE := $(shell date "+%Y-%m-%dT%H:%M")
-GIT_TAG := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
-ifeq ($(GIT_TAG),)
-VERSION := ${GIT_COMMIT}|${BUILD_DATE}
+ifeq ($(OS),Windows_NT)
+	space := $(subst ,, )
+	BUILD_DATE := $(subst $(space),,$(strip $(shell date /T))-$(shell time /T))
+	GIT_TAG := $(shell git describe --abbrev=0 --tags 2> nul)
+	ENV_CMD := set GOPRIVATE="github.com/reinventingscience/ivcap-core-api" &&
+	EXTENSION := .exe
 else
-VERSION := $(GIT_TAG:v%=%)|${GIT_COMMIT}|${BUILD_DATE}
+	BUILD_DATE := $(shell date "+%Y-%m-%dT%H:%M")
+	GIT_TAG := $(shell git describe --abbrev=0 --tags 2>/dev/null || true)
+	ENV_CMD := export GOPRIVATE="github.com/reinventingscience/ivcap-core-api" &&
+endif
+
+ifeq ($(GIT_TAG),)
+	VERSION := "${GIT_COMMIT}${BUILD_DATE}"
+else
+	VERSION := "$(GIT_TAG)|${GIT_COMMIT}|${BUILD_DATE}"
 endif
 
 build:
-	env GOPRIVATE="github.com/reinventingscience/ivcap-core-api" go mod tidy
-	go build -ldflags "-X main.version=${GIT_TAG} -X main.commit=${GIT_COMMIT} -X main.date=${BUILD_DATE}" -o ivcap
+	@echo "Building IVCAP-CLI..."
+	${ENV_CMD} go mod tidy
+	go build -ldflags "-X main.version=${GIT_TAG} -X main.commit=${GIT_COMMIT} -X main.date=${BUILD_DATE}" -o ivcap${EXTENSION}
 
 install: build
 	cp ivcap $(shell go env GOBIN)

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ ifeq ($(OS),Windows_NT)
 	space := $(subst ,, )
 	BUILD_DATE := $(subst $(space),,$(strip $(shell date /T))-$(shell time /T))
 	GIT_TAG := $(shell git describe --abbrev=0 --tags 2> nul)
-	ENV_CMD := set GOPRIVATE="github.com/reinventingscience/ivcap-core-api" &&
+	GOPRIVATE_OS_ENV_CMD := set GOPRIVATE="github.com/reinventingscience/ivcap-core-api" &&
 	EXTENSION := .exe
 else
 	BUILD_DATE := $(shell date "+%Y-%m-%dT%H:%M")
 	GIT_TAG := $(shell git describe --abbrev=0 --tags 2>/dev/null || true)
-	ENV_CMD := export GOPRIVATE="github.com/reinventingscience/ivcap-core-api" &&
+	GOPRIVATE_OS_ENV_CMD := export GOPRIVATE="github.com/reinventingscience/ivcap-core-api" &&
 endif
 
 ifeq ($(GIT_TAG),)
@@ -20,7 +20,7 @@ endif
 
 build:
 	@echo "Building IVCAP-CLI..."
-	${ENV_CMD} go mod tidy
+	${GOPRIVATE_ENV_CMD} go mod tidy
 	go build -ldflags "-X main.version=${GIT_TAG} -X main.commit=${GIT_COMMIT} -X main.date=${BUILD_DATE}" -o ivcap${EXTENSION}
 
 install: build


### PR DESCRIPTION
Update Makefile to work on Windows

This involved handling the difference time/date generation functions - as a result the date string on a Windows build will be a different format to the unix version. 

This requires installation of a Windows version of GNU Make. 

It may be better in the future to setup the environment external to the Makefile (and hence moving any OS specific commands into shell scripts), and then keeping the Makefile OS agnostic but this will work for now. 

This work came about from reviewing PR #5 . 