### PR TITLE
Primarily replacing direct HTTP calls with Adapter API

### DIFF
--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -360,7 +360,7 @@ func downloadArtifact(cmd *cobra.Command, args []string) error {
 
 	downloadHandler := func(resp *http.Response, path string, logger *log.Logger) (err error) {
 		if resp.StatusCode >= 300 {
-			return a.ProcessErrorResponse(resp, path, "", logger)
+			return a.ProcessErrorResponse(resp, path, nil, logger)
 		}
 
 		var outFile *os.File

--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -312,19 +312,30 @@ func upload(
 	offset int64,
 	adapter *a.Adapter,
 ) (err error) {
-	if err = sdk.UploadArtifact(ctxt, reader, size, offset, chunkSize, path, adapter, logger); err != nil {
+	if err = sdk.UploadArtifact(ctxt, reader, size, offset, chunkSize, path, adapter, silent, logger); err != nil {
 		cobra.CompErrorln(fmt.Sprintf("while uploading data file '%s' - %v", inputFile, err))
 		return
 	}
-	fmt.Printf("Completed uploading '%s'\n", artifactID)
-
+	if !silent {
+		fmt.Printf("Completed uploading '%s'\n", artifactID)
+	}
 	readReq := &sdk.ReadArtifactRequest{Id: artifactID}
-	var readResp *api.ReadResponseBody
-	if readResp, err = sdk.ReadArtifact(ctxt, readReq, adapter, logger); err == nil {
-		printArtifact(readResp, false)
-	} else {
-		cobra.CompErrorln(fmt.Sprintf("while getting a status update on '%s' - %v", artifactID, err))
-		return
+
+	switch outputFormat {
+	case "json", "yaml":
+		if res, err := sdk.ReadArtifactRaw(ctxt, readReq, adapter, logger); err == nil {
+			a.ReplyPrinter(res, outputFormat == "yaml")
+		} else {
+			return err
+		}
+	default:
+		var readResp *api.ReadResponseBody
+		if readResp, err = sdk.ReadArtifact(ctxt, readReq, adapter, logger); err == nil {
+			printArtifact(readResp, false)
+		} else {
+			cobra.CompErrorln(fmt.Sprintf("while getting a status update on '%s' - %v", artifactID, err))
+			return
+		}
 	}
 	return
 }
@@ -361,7 +372,12 @@ func downloadArtifact(cmd *cobra.Command, args []string) error {
 				return
 			}
 		}
-		reader := sdk.AddProgressBar("... downloading file", resp.ContentLength, resp.Body)
+		var reader io.Reader
+		if silent {
+			reader = resp.Body
+		} else {
+			reader = sdk.AddProgressBar("... downloading file", resp.ContentLength, resp.Body)
+		}
 		_, err = io.Copy(outFile, reader)
 		return
 	}

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -116,7 +116,7 @@ var getContextCmd = &cobra.Command{
 	Short:   "Display the current context",
 	Aliases: []string{"current", "show"},
 	Run: func(_ *cobra.Command, args []string) {
-		param := "name"
+		param := "all"
 		if len(args) == 1 {
 			param = args[0]
 		}
@@ -125,7 +125,7 @@ var getContextCmd = &cobra.Command{
 			fmt.Println(context.Name)
 		} else if param == "access-token" {
 			if IsAuthorised() {
-				fmt.Println(context.AccessToken)
+				fmt.Println(getAccessToken(true))
 			} else {
 				at := "NOT AUTHORISED\n"
 				if silent {
@@ -150,7 +150,11 @@ var getContextCmd = &cobra.Command{
 			}
 			isAuth := "no"
 			if IsAuthorised() {
-				isAuth = fmt.Sprintf("yes, refreshed after %s", context.AccessTokenExpiry.Format(time.RFC822))
+				if accessTokenProvided {
+					isAuth = fmt.Sprintf("unknown, token provided via '--access-token' flag or environment variable '%s'", ACCESS_TOKEN_ENV)
+				} else {
+					isAuth = fmt.Sprintf("yes, refreshing after %s", context.AccessTokenExpiry.Format(time.RFC822))
+				}
 			}
 			t.AppendRow(table.Row{"Authorised", isAuth})
 			if context.Host != "" {

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -18,19 +18,16 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 )
 
-var ctxtName string
-var ctxtUrl string
-var ctxtApiVersion int
-
 var (
-	accountID  string
-	providerID string
-	hostName   string
+	ctxtName       string
+	ctxtApiVersion int
+	hostName       string
 )
 
 // configCmd represents the config command
@@ -40,21 +37,14 @@ var configCmd = &cobra.Command{
 	Aliases: []string{"c"},
 }
 
-var setContextCmd = &cobra.Command{
-	Use:   "create ctxtName --url https://ivcap.net",
+var createContextCmd = &cobra.Command{
+	Use:   "create ctxtName https://ivcap.net",
 	Short: "Create a new context",
+	Args:  cobra.ExactArgs(2),
 	//Aliases: []string{"create"},
 	Run: func(_ *cobra.Command, args []string) {
-		if ctxtName == "" {
-			if len(args) > 0 {
-				ctxtName = args[0]
-			} else {
-				cobra.CheckErr("Missing 'name' argument or '--name' flag")
-			}
-		}
-		if ctxtUrl == "" {
-			cobra.CheckErr("Missing '--url' flag")
-		}
+		ctxtName = args[0]
+		ctxtUrl := args[1]
 		url, err := url.ParseRequestURI(ctxtUrl)
 		if err != nil || url.Host == "" {
 			cobra.CheckErr(fmt.Sprintf("url '%s' is not a valid URL", ctxtUrl))
@@ -64,8 +54,6 @@ var setContextCmd = &cobra.Command{
 			ApiVersion: ctxtApiVersion,
 			Name:       ctxtName,
 			URL:        ctxtUrl,
-			AccountID:  accountID,
-			ProviderID: providerID,
 			Host:       hostName,
 		}
 		SetContext(ctxt, false)
@@ -78,7 +66,7 @@ var listContextCmd = &cobra.Command{
 	Short: "List all context",
 	//Aliases: []string{"get-context", "list"},
 	Run: func(_ *cobra.Command, _ []string) {
-		config, _ := ReadConfigFile(false)
+		config, _ := ReadConfigFile(true)
 		if config != nil {
 			t := table.NewWriter()
 			t.SetOutputMirror(os.Stdout)
@@ -136,11 +124,15 @@ var getContextCmd = &cobra.Command{
 		if param == "name" {
 			fmt.Println(context.Name)
 		} else if param == "access-token" {
-			t := table.NewWriter()
-			t.SetOutputMirror(os.Stdout)
-			t.AppendRow(table.Row{"Access Token", context.AccessToken})
-			t.AppendRow(table.Row{"Token Expiry", context.AccessTokenExpiry})
-			t.Render()
+			if IsAuthorised() {
+				fmt.Println(context.AccessToken)
+			} else {
+				at := "NOT AUTHORISED\n"
+				if silent {
+					at = ""
+				}
+				fmt.Print(at)
+			}
 		} else if param == "account-id" {
 			fmt.Println(context.AccountID)
 		} else if param == "provider-id" {
@@ -156,9 +148,15 @@ var getContextCmd = &cobra.Command{
 			if context.ProviderID != "" {
 				t.AppendRow(table.Row{"Provider ID", context.ProviderID})
 			}
+			isAuth := "no"
+			if IsAuthorised() {
+				isAuth = fmt.Sprintf("yes, until %s", context.AccessTokenExpiry.Format(time.RFC822))
+			}
+			t.AppendRow(table.Row{"Authorised", isAuth})
 			if context.Host != "" {
 				t.AppendRow(table.Row{"Host", context.Host})
 			}
+
 			t.Render()
 		} else {
 			cobra.CheckErr(fmt.Sprintf("unknown context parameter '%s'", param))
@@ -171,12 +169,12 @@ func init() {
 
 	configCmd.AddCommand(listContextCmd)
 
-	configCmd.AddCommand(setContextCmd)
-	setContextCmd.Flags().StringVar(&ctxtUrl, "url", "", "The url to the IVCAP deployment (e.g. https://api.green-cirrus.com)")
-	setContextCmd.Flags().StringVar(&accountID, "account-id", "", "The account ID to use. Will most likely be set on login")
-	setContextCmd.Flags().StringVar(&providerID, "provider-id", "", "The account ID to use. Will most likely be set on login")
-	setContextCmd.Flags().StringVar(&hostName, "host-name", "", "optional host name if accessing API through SSH tunnel")
-	setContextCmd.Flags().IntVar(&ctxtApiVersion, "version", 1, "define API version")
+	configCmd.AddCommand(createContextCmd)
+	// We don't really use them right, so better not confuse anyone
+	// createContextCmd.Flags().StringVar(&accountID, "account-id", "", "The account ID to use. Will most likely be set on login")
+	// createContextCmd.Flags().StringVar(&providerID, "provider-id", "", "The account ID to use. Will most likely be set on login")
+	createContextCmd.Flags().StringVar(&hostName, "host-name", "", "optional host name if accessing API through SSH tunnel")
+	createContextCmd.Flags().IntVar(&ctxtApiVersion, "version", 1, "define API version")
 
 	configCmd.AddCommand(useContextCmd)
 

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -150,7 +150,7 @@ var getContextCmd = &cobra.Command{
 			}
 			isAuth := "no"
 			if IsAuthorised() {
-				isAuth = fmt.Sprintf("yes, until %s", context.AccessTokenExpiry.Format(time.RFC822))
+				isAuth = fmt.Sprintf("yes, refreshed after %s", context.AccessTokenExpiry.Format(time.RFC822))
 			}
 			t.AppendRow(table.Row{"Authorised", isAuth})
 			if context.Host != "" {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/golang-jwt/jwt/v4"
+	adpt "github.com/reinventingscience/ivcap-client/pkg/adapter"
 	"github.com/skip2/go-qrcode"
 	"github.com/spf13/cobra"
 	log "go.uber.org/zap"
@@ -37,6 +37,19 @@ var loginCmd = &cobra.Command{
 	Run:   login,
 }
 
+var logoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Remove authentication tokens from specific deployment/context",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		ctxt := GetActiveContext()
+		ctxt.AccessToken = ""
+		ctxt.AccessTokenExpiry = time.Time{}
+		ctxt.RefreshToken = ""
+		SetContext(ctxt, true)
+		return
+	},
+}
+
 type CaddyFaultResponse struct {
 	Name      string
 	Id        string
@@ -47,22 +60,17 @@ type CaddyFaultResponse struct {
 }
 
 type AuthInfo struct {
-	Version           string                  `yaml:"version"`
+	Version      int              `yaml:"version"`
+	ProviderList AuthProviderInfo `yaml:"auth"`
+}
+
+type AuthProviderInfo struct {
 	DefaultProviderId string                  `yaml:"default-provider-id"`
 	AuthProviders     map[string]AuthProvider `yaml:"providers"`
 }
 
-func (authInfo AuthInfo) GetDefaultProvider() (authProvider *AuthProvider, err error) {
-	defaultProvider, hasDefaultProvider := authInfo.AuthProviders[authInfo.DefaultProviderId]
-	if hasDefaultProvider {
-		return &defaultProvider, nil
-	} else {
-		return nil, fmt.Errorf("Default Provider Id does not exist")
-	}
-}
-
 type AuthProvider struct {
-	ID        string `yaml:"id"`
+	ID        string `yaml:"id,omitempty"`
 	LoginURL  string `yaml:"login-url"`
 	TokenURL  string `yaml:"token-url"`
 	CodeURL   string `yaml:"code-url"`
@@ -83,12 +91,14 @@ type DeviceCode struct {
 }
 
 type CustomIdClaims struct {
-	Name          string `json:"name,omitempty"`
-	Nickname      string `json:"nickname,omitempty"`
-	Email         string `json:"email,omitempty"`
-	EmailVerified bool   `json:"email_verified,omitempty"`
-	Picture       string `json:"picture,omitempty"`
-	AccountID     string `json:"ivap/claims/account-id,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	Nickname      string   `json:"nickname,omitempty"`
+	Email         string   `json:"email,omitempty"`
+	EmailVerified bool     `json:"email_verified,omitempty"`
+	Avatar        string   `json:"picture,omitempty"`
+	AccountID     string   `json:"acc"`
+	ProviderID    string   `json:"ivcap/claims/provider,omitempty"`
+	GroupIDs      []string `json:"ivcap/claims/groupIds,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -102,208 +112,157 @@ type deviceTokenResponse struct {
 
 // If we already have a refresh token, we don't need to go through the whole device code
 // interaction. We can simply use the refresh token to request another access token.
-func refreshAccessToken() (accessToken string, err error) {
+func getFreshAccessToken() (accessToken string) {
 	ctxt := GetActiveContext()
-
 	accessTokenExpiry := ctxt.AccessTokenExpiry
 	if time.Now().After(accessTokenExpiry) {
 		if ctxt.RefreshToken == "" {
 			// We don't have a refresh token for this context, so we fail early
-			return "", fmt.Errorf("Could not login - invalid credentials. Please use the login command to refresh your credentials")
-		}
-
-		authProvider, err := getLoginInformation(http.DefaultClient, ctxt)
-
-		if err != nil {
-			cobra.CheckErr(fmt.Sprintf("Could not connect to %s - %s", ctxt.URL, err))
-			return "", err
+			cobra.CheckErr("Could not login - invalid credentials. Please use the login command to refresh your credentials")
 		}
 
 		// Access token has expired, we have to refresh it
+		authProvider := getLoginInformation(ctxt)
 		authProvider.grantType = "refresh_token"
 
 		if (authProvider.TokenURL != "") && (authProvider.ClientID != "") {
-
-			response, err := http.PostForm(authProvider.TokenURL,
-				url.Values{"grant_type": {authProvider.grantType},
-					"client_id":     {authProvider.ClientID},
-					"refresh_token": {ctxt.RefreshToken}})
-
-			if err != nil {
-				return "", fmt.Errorf("Cannot refresh access token - %s", err)
+			params := url.Values{
+				"refresh_token": {ctxt.RefreshToken},
+			}
+			tokenResponse := getTokenResponse(authProvider, params, ctxt, false)
+			if tokenResponse.ErrorString != "" {
+				logger.Warn("tokenResponse", log.String("error", tokenResponse.ErrorString))
+				cobra.CheckErr("oauth: Unexpected error from authentication provider")
 			}
 
-			var tokenResponse deviceTokenResponse
-			jsonDecoder := json.NewDecoder(response.Body)
-			if err := jsonDecoder.Decode(&tokenResponse); err != nil {
-				return "", fmt.Errorf("Cannot decode token response - %s", err)
-			}
+			ctxt.AccessToken = tokenResponse.AccessToken
+			ctxt.RefreshToken = tokenResponse.RefreshToken
+			// Add a 10 second buffer to expiry to account for differences in clock time between client
+			// server and message transport time (oauth2 library does the same thing)
+			ctxt.AccessTokenExpiry = time.Now().Add(time.Second * time.Duration(tokenResponse.ExpiresIn-10))
 
-			switch tokenResponse.ErrorString {
-			case "authorization_pending":
-				// No op - we're waiting on the user to open the link and login
-			case "expired_token":
-				return "", fmt.Errorf("The login process was not completed in time - please login again")
-			case "access_denied":
-				return "", fmt.Errorf("Could not login - access was denied")
-			case "invalid_grant":
-				return "", fmt.Errorf("Could not login - expired credentials. Please use the login command to refresh your credentials")
-			case "":
-				// No Errors:
-				ctxt.AccessToken = tokenResponse.AccessToken
-				// Add a 10 second buffer to expiry to account for differences in clock time between client
-				// server and message transport time (oauth2 library does the same thing)
-				ctxt.AccessTokenExpiry = time.Now().Add(time.Second * time.Duration(tokenResponse.ExpiresIn-10))
-
-				// We also get an updated ID token, let's make sure we have the latest info
-				ParseIDToken(&tokenResponse, ctxt, authProvider.JwksURL)
-
-				fmt.Println(fmt.Sprintf("Successfully acquired new access token. Expiry: %s", ctxt.AccessTokenExpiry))
-
-				SetContext(ctxt, true)
-			}
-
+			// We also get an updated ID token, let's make sure we have the latest info
+			ParseIDToken(&tokenResponse, ctxt, authProvider.JwksURL)
+			SetContext(ctxt, true)
+			fmt.Printf("Successfully acquired new access token. Expiry: %s", ctxt.AccessTokenExpiry.Format(time.RFC822))
 		} // Access token has not expired, let's just use it
 	}
 
-	return ctxt.AccessToken, nil
+	return ctxt.AccessToken
 }
 
-func getLoginInformation(client *http.Client, ctxt *Context) (authProvider *AuthProvider, err error) {
-	if ctxt == nil {
-		return nil, fmt.Errorf("Invalid config set. Please set a valid config with the config command.")
+func IsAuthorised() bool {
+	ctxt := GetActiveContext()
+	if ctxt.AccessToken == "" {
+		return false
 	}
+	accessTokenExpiry := ctxt.AccessTokenExpiry
+	return !time.Now().After(accessTokenExpiry)
+}
 
-	print(fmt.Sprintf("Sending Request to %s\n", ctxt.URL))
+func getTokenResponse(authProvider *AuthProvider, params url.Values, ctxt *Context, allowStatusForbidden bool) (tokenResponse deviceTokenResponse) {
+	adapter := CreateAdapter(false)
+	params.Set("grant_type", authProvider.grantType)
+	params.Set("client_id", authProvider.ClientID)
 
-	response, err := http.Get(ctxt.URL + "/1/authinfo.yaml")
-
+	var pyld adpt.Payload
+	var err error
+	pyld, err = (*adapter).PostForm(NewTimeoutContext(), authProvider.TokenURL, params, nil, logger)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot request login info - %s", err)
-	}
-
-	responseMap := make(map[string]interface{})
-	yamlDecoder := yaml.NewDecoder(response.Body)
-	yamlDecoder.KnownFields(true) // Make sure if we get a dodgy response to error out
-	if err := yamlDecoder.Decode(&responseMap); err != nil {
-		return nil, fmt.Errorf("unknown response from Login Service")
-	}
-
-	// Check if caddy has returned a fault
-	if responseMap["fault"] == true {
-		faultResponse, _ := yaml.Marshal(responseMap)
-		logger.Warn("Login Service Fault:\n", log.String("login service response:", string(faultResponse)))
-		return nil, fmt.Errorf("login service has returned a fault")
-	}
-
-	// Check the version number
-	versionNum, hasVersionValue := responseMap["version"]
-	if !hasVersionValue {
-		response, _ := yaml.Marshal(responseMap)
-		logger.Warn("Login Service provided No Version Info:\n", log.String("login service response:", string(response)))
-		panic(1)
-		return nil, fmt.Errorf("login service returned an invalid response")
-	} else if versionNum == 1 {
-		// Marshal the auth struct into a byte array so we unmarshal it into
-		// the correct struct
-		yamlAuth, err := yaml.Marshal(responseMap["auth"])
-		if err != nil {
-			return nil, fmt.Errorf("could not process login service response")
-		}
-		var authInfo AuthInfo
-		err = yaml.Unmarshal(yamlAuth, &authInfo)
-		if err != nil {
-			return nil, fmt.Errorf("could not process login service response (auth providers)")
-		}
-
-		if len(authInfo.AuthProviders) != 0 {
-			// Return the provider specified by the default provider id
-			defaultProvider, err := authInfo.GetDefaultProvider()
-			if err != nil {
-				return nil, fmt.Errorf("Login Service returned invalid data (No Default Provider)")
+		if apiErr, ok := err.(*adpt.ApiError); ok && allowStatusForbidden {
+			if apiErr.StatusCode == http.StatusForbidden {
+				pyld = apiErr.Pyld
 			} else {
-				return defaultProvider, nil
+				cobra.CheckErr(fmt.Sprintf("Cannot obtain OAuth Token - %s", err))
 			}
 		} else {
-			return nil, fmt.Errorf("Login Service returned invalid data (No Providers)")
+			cobra.CheckErr(fmt.Sprintf("Cannot obtain OAuth Token - %s", err))
+			return // never reached
 		}
-	} else {
-		// Unknown version
-		response, _ := yaml.Marshal(responseMap)
-		logger.Warn("Login Service No Version:\n", log.String("login service response:", string(response)))
-		return nil, fmt.Errorf("client out of date: Please update this application")
 	}
+
+	if err = pyld.AsType(&tokenResponse); err != nil {
+		logger.Error("while parsing 'deviceTokenResponse'", log.String("pyld", string(pyld.AsBytes())))
+		cobra.CheckErr("oauth: Cannot decode token response")
+		return
+	}
+
+	switch tokenResponse.ErrorString {
+	case "expired_token":
+		cobra.CheckErr("The login process was not completed in time - please login again")
+	case "access_denied":
+		cobra.CheckErr("Could not login - access was denied")
+	case "invalid_grant":
+		cobra.CheckErr("Could not login - expired credentials. Please use the login command to refresh your credentials")
+	}
+	return
 }
 
-func requestDeviceCode(client *http.Client, authProvider *AuthProvider) (*DeviceCode, error) {
-	response, err := http.PostForm(authProvider.CodeURL,
-		url.Values{"client_id": {authProvider.ClientID},
-			"scope":    {authProvider.scopes},
-			"audience": {authProvider.audience}})
-
+func getLoginInformation(ctxt *Context) (authProvider *AuthProvider) {
+	adpt := CreateAdapter(false)
+	pyld, err := (*adpt).Get(NewTimeoutContext(), "/1/authinfo.yaml", logger)
 	if err != nil {
-		cobra.CheckErr(fmt.Sprintf("Cannot request authentication device code - %s", err))
-		return nil, err
+		return
 	}
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP Request Error: Device code request returned %v (%v)",
-			response.StatusCode, http.StatusText(response.StatusCode))
+	var ai AuthInfo
+	if err = yaml.Unmarshal(pyld.AsBytes(), &ai); err != nil {
+		return
 	}
-
-	// Read the device code from the body of the returned response
-	var deviceCode DeviceCode
-	jsonDecoder := json.NewDecoder(response.Body)
-	if err := jsonDecoder.Decode(&deviceCode); err != nil {
-		return nil, err
+	if ai.Version != 1 {
+		cobra.CheckErr("oauth: Client out of date: Please update this application")
 	}
-
-	return &deviceCode, nil
+	providers := ai.ProviderList.AuthProviders
+	defProvider := ai.ProviderList.DefaultProviderId
+	if provider, ok := providers[defProvider]; ok {
+		return &provider
+	}
+	if defProvider != "" {
+		cobra.CheckErr(fmt.Sprintf("oauth: Undeclared Authentication Provider '%s' returned", defProvider))
+	}
+	// If no default provider is given, just pick the first one
+	for _, p := range providers {
+		return &p
+	}
+	cobra.CheckErr("oauth: Cannot extract a suitable Authentication Provider")
+	return // never get here
 }
 
-func waitForTokens(client *http.Client, authProvider *AuthProvider, deviceCode *DeviceCode) (*deviceTokenResponse, error) {
+func requestDeviceCode(authProvider *AuthProvider) (code *DeviceCode) {
+	adpt := CreateAdapter(false)
+	params := url.Values{
+		"client_id": {authProvider.ClientID},
+		"scope":     {authProvider.scopes},
+		"audience":  {authProvider.audience},
+	}
+	pyld, err := (*adpt).PostForm(NewTimeoutContext(), authProvider.CodeURL, params, nil, logger)
+	if err != nil {
+		cobra.CheckErr("oauth: Error while requesting device code from authentication provider")
+		return
+	}
+
+	var dc DeviceCode
+	if err = pyld.AsType(&dc); err != nil {
+		logger.Error("while parsing 'DeviceCode'", log.String("pyld", string(pyld.AsBytes())))
+		cobra.CheckErr("oauth: Cannot understand device information returned from authentication provider")
+		return
+	}
+	return &dc
+}
+
+func waitForTokens(authProvider *AuthProvider, deviceCode *DeviceCode, ctxt *Context) *deviceTokenResponse {
 	// We keep requesting until we're told not to by the server (too much time elapsed
 	// for the user to login
 	startTime := time.Now()
 	lastElapsedTime := int64(0)
+
+	params := url.Values{
+		"device_code": {deviceCode.DeviceCode},
+	}
 	for {
-		response, err := http.PostForm(authProvider.TokenURL,
-			url.Values{"grant_type": {authProvider.grantType},
-				"client_id":   {authProvider.ClientID},
-				"device_code": {deviceCode.DeviceCode}})
-
-		if err != nil {
-			return nil, fmt.Errorf("Cannot request tokens - %s", err)
-		}
-
-		// Auth0 unfortunately returns statusforbidden while we're waiting for a token, so
-		// we can't just exist here if != statusOk
-		if (response.StatusCode != http.StatusOK) && (response.StatusCode != http.StatusForbidden) {
-			return nil, fmt.Errorf("HTTP Request Error: Token Request returned %v (%v)",
-				response.StatusCode,
-				http.StatusText(response.StatusCode))
-		}
-
-		/*
-			responseRaw, err := io.ReadAll(response.Body)
-			var dat map[string]interface{}
-			if err := json.Unmarshal(responseRaw, &dat); err != nil {
-				panic(err)
-			}
-			fmt.Println(dat)
-			if dat["error"] != nil {
-				errorvalue := dat["error"].(string)
-				if errorvalue != "" {
-					fmt.Println(errorvalue)
-					time.Sleep(time.Duration(deviceCode.Interval) * time.Second)
-					continue
-				}
-			}
-		*/
-
-		var tokenResponse deviceTokenResponse
-		jsonDecoder := json.NewDecoder(response.Body)
-		if err := jsonDecoder.Decode(&tokenResponse); err != nil {
-			return nil, fmt.Errorf("Cannot decode token response - %s", err)
+		tokenResponse := getTokenResponse(authProvider, params, ctxt, true)
+		logger.Debug("oauth: token response", log.Reflect("tr", tokenResponse))
+		if tokenResponse.ErrorString == "" {
+			return &tokenResponse
 		}
 
 		switch tokenResponse.ErrorString {
@@ -314,92 +273,84 @@ func waitForTokens(client *http.Client, authProvider *AuthProvider, deviceCode *
 			// device code request response, but the server has complained, we're going to increase
 			// the wait interval
 			deviceCode.Interval *= 2
-		case "expired_token":
-			return nil, fmt.Errorf("The login process was not completed in time - please login again")
-		case "access_denied":
-			return nil, fmt.Errorf("Could not login - access was denied")
-		case "invalid_grant":
-			return nil, fmt.Errorf("Could not login - invalid credentials")
-		case "":
-			// No Errors:
-			return &tokenResponse, nil
+		default:
+			cobra.CheckErr(fmt.Sprintf("oauth: Authentication provider returned unexpected error '%s'", tokenResponse.ErrorString))
 		}
 
 		elapsedTime := int64(time.Since(startTime).Seconds())
 		if elapsedTime/60 != lastElapsedTime/60 {
-			fmt.Println(fmt.Sprintf("Time remaining: %d seconds", deviceCode.ExpiresIn-elapsedTime))
+			fmt.Printf("... Time remaining: %d seconds\n", deviceCode.ExpiresIn-elapsedTime)
 		}
 		lastElapsedTime = elapsedTime
 
 		// We sleep until we're allowed to poll again
 		time.Sleep(time.Duration(deviceCode.Interval) * time.Second)
 	}
-
 }
 
-func ParseIDToken(tokenResponse *deviceTokenResponse, ctxt *Context, jwksURL string) error {
+func ParseIDToken(tokenResponse *deviceTokenResponse, ctxt *Context, jwksURL string) {
 	// Lookup the public key to verify the signature (and check we have a valid token)
 
 	// TODO: Download and cache the jwks data rather than download it on every login / token
 	// refresh
 	jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{})
-
-	idToken, err := jwt.ParseWithClaims(tokenResponse.IDToken, &CustomIdClaims{}, jwks.Keyfunc)
-
 	if err != nil {
-		if errors.Is(err, jwt.ErrTokenMalformed) {
-			return fmt.Errorf("Malformed ID Token Received - %s", err)
+		cobra.CheckErr(fmt.Sprintf("cannot load the JWKS - %s", err))
+	}
+	idToken, err := jwt.ParseWithClaims(tokenResponse.IDToken, &CustomIdClaims{}, jwks.Keyfunc)
+	if err != nil {
+		if errors.Is(err, jwt.ErrTokenUsedBeforeIssued) {
+			// let's wait a bit and try again as this is most likely due to clock shifts as we immediately check
+			// token after it has been created.
+			logger.Info("oauth: Waiting a few seconds as token is not valid yet")
+			time.Sleep(time.Duration(3 * time.Second))
+			ParseIDToken(tokenResponse, ctxt, jwksURL)
+			return
+		} else if errors.Is(err, jwt.ErrTokenMalformed) {
+			cobra.CheckErr(fmt.Sprintf("malformed ID Token received - %s", err))
 		} else if errors.Is(err, jwt.ErrTokenExpired) || errors.Is(err, jwt.ErrTokenNotValidYet) {
 			// Token is either expired or not active yet
-			return fmt.Errorf("Expired ID Token Received - %s", err)
+			cobra.CheckErr(fmt.Sprintf("expired ID Token received - %s", err))
 		} else {
-			return fmt.Errorf("Cannot verify ID token - %s", err)
+			cobra.CheckErr(fmt.Sprintf("cannot verify ID token - %s", err))
 		}
 	}
 
-	if idToken != nil {
-		if claims, ok := idToken.Claims.(*CustomIdClaims); ok && idToken.Valid {
-			// Save the data from the ID token into the config/context
-			ctxt.AccountName = claims.Name
-			ctxt.Email = claims.Email
-			ctxt.AccountNickName = claims.Nickname
-			ctxt.AccountID = claims.AccountID
-		}
+	if idToken == nil {
+		cobra.CheckErr("Should never happen. No 'idToken' and no error")
 	}
-
-	return nil
+	if claims, ok := idToken.Claims.(*CustomIdClaims); ok && idToken.Valid {
+		// Save the data from the ID token into the config/context
+		ctxt.AccountName = claims.Name
+		ctxt.Email = claims.Email
+		ctxt.AccountNickName = claims.Nickname
+		ctxt.AccountID = fmt.Sprintf("urn:%s:account:%s", URN_PREFIX, claims.AccountID)
+		providerID := claims.ProviderID
+		if providerID == "" {
+			providerID = claims.AccountID
+		}
+		ctxt.ProviderID = fmt.Sprintf("urn:%s:provider:%s", URN_PREFIX, providerID)
+	}
 }
 
 func login(_ *cobra.Command, args []string) {
-	ctxt := GetActiveContext()
-
-	httpClient := http.DefaultClient
-
-	if ctxt == nil {
-		cobra.CheckErr("Invalid config set. Please set a valid config with the config command.")
-		return
-	}
-	authProvider, err := getLoginInformation(httpClient, ctxt)
-
-	if err != nil {
-		cobra.CheckErr(fmt.Sprintf("Could not connect to %s to login - %s", ctxt.URL, err))
-		return
-	}
+	ctxt := GetActiveContext() // will always return ctxt or have already failed
+	authProvider := getLoginInformation(ctxt)
 
 	// offline_access is required for the refresh tokens to be sent through
 	authProvider.scopes = "openid profile email offline_access"
 	authProvider.grantType = "urn:ietf:params:oauth:grant-type:device_code"
+	// TODO: Shouldn't that come from the server?
 	authProvider.audience = "https://api.ivcap.net/"
 
 	// First request a device code for this command line tool
-	deviceCode, err := requestDeviceCode(httpClient, authProvider)
+	deviceCode := requestDeviceCode(authProvider)
 
-	if err != nil {
-		cobra.CheckErr(fmt.Sprintf("Cannot request authentication device code - %s", err))
-		return
-	}
-
+	// Show QR code for authenticating via a web browser
 	qrCode, err := qrcode.New(deviceCode.VerificationURLComplete, qrcode.Medium)
+	if err != nil {
+		cobra.CheckErr(fmt.Sprintf("cannot create QR code - %s", err))
+	}
 	qrCodeStrings := qrCode.ToSmallString(true)
 
 	fmt.Println(string(qrCodeStrings))
@@ -411,18 +362,8 @@ func login(_ *cobra.Command, args []string) {
 	fmt.Println("or scan the QR Code to be taken to the login page")
 	fmt.Println("Waiting for authorisation...")
 
-	tokenResponse, err := waitForTokens(httpClient, authProvider, deviceCode)
-	if err != nil {
-		cobra.CheckErr(fmt.Sprintf("Cannot request authorisation tokens - %s", err))
-		return
-	}
-
-	fmt.Println(fmt.Sprintf("Command Line Tool Authorised."))
-	err = ParseIDToken(tokenResponse, ctxt, authProvider.JwksURL)
-	if err != nil {
-		cobra.CheckErr(fmt.Sprintf("Cannot parse identity information - %s", err))
-		return
-	}
+	tokenResponse := waitForTokens(authProvider, deviceCode, ctxt)
+	ParseIDToken(tokenResponse, ctxt, authProvider.JwksURL)
 
 	ctxt.AccessToken = tokenResponse.AccessToken
 	// Add a 10 second buffer to expiry to account for differences in clock time between client
@@ -431,9 +372,13 @@ func login(_ *cobra.Command, args []string) {
 	ctxt.RefreshToken = tokenResponse.RefreshToken
 	SetContext(ctxt, true)
 
-	// fmt.Println(fmt.Sprintf("Access Token Expires at: %s", ctxt.AccessTokenExpiry))
+	fmt.Printf("Success: You are authorised until %s.\n", ctxt.AccessTokenExpiry.Format(time.RFC822))
+}
+
+func logout(_ *cobra.Command, args []string) {
 }
 
 func init() {
 	rootCmd.AddCommand(loginCmd)
+	rootCmd.AddCommand(logoutCmd)
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -171,7 +171,7 @@ func getTokenResponse(authProvider *AuthProvider, params url.Values, ctxt *Conte
 	if err != nil {
 		if apiErr, ok := err.(*adpt.ApiError); ok && allowStatusForbidden {
 			if apiErr.StatusCode == http.StatusForbidden {
-				pyld = apiErr.Pyld
+				pyld = apiErr.Payload
 			} else {
 				cobra.CheckErr(fmt.Sprintf("Cannot obtain OAuth Token - %s", err))
 			}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -144,7 +144,7 @@ func getAccessToken() (accessToken string) {
 			// We also get an updated ID token, let's make sure we have the latest info
 			ParseIDToken(&tokenResponse, ctxt, authProvider.JwksURL)
 			SetContext(ctxt, true)
-			fmt.Printf("Successfully acquired new access token. Expiry: %s", ctxt.AccessTokenExpiry.Format(time.RFC822))
+			logger.Info("Successfully acquired new access token.", log.String("expires", ctxt.AccessTokenExpiry.Format(time.RFC822)))
 		} // Access token has not expired, let's just use it
 	}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -372,10 +372,7 @@ func login(_ *cobra.Command, args []string) {
 	ctxt.RefreshToken = tokenResponse.RefreshToken
 	SetContext(ctxt, true)
 
-	fmt.Printf("Success: You are authorised until %s.\n", ctxt.AccessTokenExpiry.Format(time.RFC822))
-}
-
-func logout(_ *cobra.Command, args []string) {
+	fmt.Printf("Success: You are authorised.\n")
 }
 
 func init() {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -112,7 +112,7 @@ type deviceTokenResponse struct {
 
 // If we already have a refresh token, we don't need to go through the whole device code
 // interaction. We can simply use the refresh token to request another access token.
-func getFreshAccessToken() (accessToken string) {
+func getAccessToken() (accessToken string) {
 	ctxt := GetActiveContext()
 	accessTokenExpiry := ctxt.AccessTokenExpiry
 	if time.Now().After(accessTokenExpiry) {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -136,7 +136,9 @@ func getAccessToken() (accessToken string) {
 			}
 
 			ctxt.AccessToken = tokenResponse.AccessToken
-			ctxt.RefreshToken = tokenResponse.RefreshToken
+			if tokenResponse.RefreshToken != "" {
+				ctxt.RefreshToken = tokenResponse.RefreshToken
+			}
 			// Add a 10 second buffer to expiry to account for differences in clock time between client
 			// server and message transport time (oauth2 library does the same thing)
 			ctxt.AccessTokenExpiry = time.Now().Add(time.Second * time.Duration(tokenResponse.ExpiresIn-10))

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -111,8 +111,10 @@ type deviceTokenResponse struct {
 	ErrorString string `json:"error,omitempty"`
 }
 
-// If we already have a refresh token, we don't need to go through the whole device code
-// interaction. We can simply use the refresh token to request another access token.
+// First check environment variables and command line flags for provided
+// tokens and immedaitely return them if available. Then check the 'ActiveContext'
+// for a token and if `refreshIfExpired` is set, ckeck if token is expired and
+// if it is, request a new one from the identitiy provider.
 func getAccessToken(refreshIfExpired bool) (accessToken string) {
 	if accessTokenF != "" {
 		accessTokenProvided = true
@@ -248,7 +250,7 @@ func getLoginInformation(ctxt *Context) (authProvider *AuthProvider) {
 
 func verifyProviderInfo(p *AuthProvider) *AuthProvider {
 	f := func(name string, urls string) {
-		if _, e := url.ParseRequestURI(urls); e == nil {
+		if _, e := url.ParseRequestURI(urls); e != nil {
 			cobra.CheckErr(fmt.Sprintf("oauth: Authentication provider's %s '%s' is not a valid URL - %s", name, urls, e))
 		}
 	}

--- a/cmd/order.go
+++ b/cmd/order.go
@@ -32,6 +32,7 @@ import (
 
 var (
 	name               string
+	accountID          string
 	skipParameterCheck bool
 
 	orderCmd = &cobra.Command{
@@ -143,10 +144,13 @@ An example:
 				params[i] = &api.ParameterT{Name: &name, Value: &value}
 			}
 
+			if accountID == "" {
+				accountID = GetActiveContext().AccountID
+			}
 			req := &api.CreateRequestBody{
 				ServiceID:  serviceId,
 				Parameters: params,
-				AccountID:  GetAccountID(),
+				AccountID:  accountID, // do we really need to account ID.
 			}
 			if name != "" {
 				req.Name = &name
@@ -184,6 +188,7 @@ func init() {
 	orderCmd.AddCommand(createOrderCmd)
 	createOrderCmd.Flags().StringVarP(&name, "name", "n", "", "Optional name/title attached to order")
 	createOrderCmd.Flags().StringVarP(&outputFormat, "output", "o", "short", "format to use for list (short, yaml, json)")
+	createOrderCmd.Flags().StringVar(&accountID, "account-id", "", "override the account ID to use for the order")
 	createOrderCmd.Flags().BoolVar(&skipParameterCheck, "skip-parameter-check", false, "fskip checking order paramters first ONLY USE FOR TESTING")
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,6 +103,7 @@ API exposed by a specific IVCAP deployment.`,
 
 func Execute(version string) {
 	rootCmd.Version = version
+	rootCmd.SilenceUsage = true
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
@@ -158,7 +159,7 @@ func CreateAdapterWithTimeout(requiresAuth bool, timeoutSec int) (adapter *adpt.
 			// here, so that we'll check the current access token, and if it has expired,
 			// we'll use the refresh token to get ourselves a new one. If the refresh
 			// token has expired, we'll prompt the user to login again.
-			accessToken = getFreshAccessToken()
+			accessToken = getAccessToken()
 		}
 
 		if accessToken == "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,7 @@ var (
 	offset       int
 	limit        int
 	outputFormat string
+	silent       bool
 )
 
 var logger *log.Logger
@@ -116,6 +117,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&timeout, "timeout", 10, "Max. number of seconds to wait for completion")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Set logging level to DEBUG")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "", "Set format for displaying output [json, yaml]")
+	rootCmd.PersistentFlags().BoolVar(&silent, "silent", false, "Do not show any progress information")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -148,6 +148,16 @@ func CreateAdapter(requiresAuth bool) (adapter *adpt.Adapter) {
 	return CreateAdapterWithTimeout(requiresAuth, timeout)
 }
 
+// Returns an HTTP adapter which will wait a max. of `timeoutSec` sec for a reply.
+// It also pre-configures the adapter in the following way:
+//
+//   - If `requiresAuth` is set, each outgoing request includes an `Authorization` header
+//     with a 'Bearer' token provided either via the `--access-token` flag,
+//     the IVCAP_ACCESS_TOKEN environment, or the AccessToken from the ActiveContext.
+//   - If the `path` parameter for any of the adapter calls is NOT a fully fledged URL,
+//     the URL defined in ActiveContext is automatically prefixed.
+//   - If the ActiveContext defines a `Host` parameter, it is also added as a
+//     `Host` HTTP header.
 func CreateAdapterWithTimeout(requiresAuth bool, timeoutSec int) (adapter *adpt.Adapter) {
 	ctxt := GetActiveContext() // will always return with a context
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -137,10 +137,6 @@ func (a *restAdapter) Delete(ctxt context.Context, path string, logger *log.Logg
 	return Connect(ctxt, "DELETE", path, nil, -1, nil, &a.ctxt, nil, logger)
 }
 
-func (a *restAdapter) ClearAuthorization() {
-	a.ctxt.AccessToken = ""
-}
-
 func (a *restAdapter) SetUrl(url string) {
 	a.ctxt.URL = url
 }

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -74,7 +74,7 @@ func (e *UnauthorizedError) Error() string { return "Unauthorized access" }
 type ApiError struct {
 	AdapterError
 	StatusCode int
-	Pyld       Payload
+	Payload    Payload
 }
 
 func (e *ApiError) Error() string {
@@ -257,7 +257,7 @@ func ProcessErrorResponse(resp *http.Response, path string, pyld Payload, logger
 		return &ApiError{
 			AdapterError: AdapterError{path},
 			StatusCode:   resp.StatusCode,
-			Pyld:         pyld,
+			Payload:      pyld,
 		}
 	}
 }

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -78,8 +78,8 @@ type ApiError struct {
 }
 
 func (e *ApiError) Error() string {
-	if e.Pyld != nil {
-		return string(e.Pyld.AsBytes())
+	if e.Payload != nil && !e.Payload.IsEmpty() {
+		return string(e.Payload.AsBytes())
 	} else {
 		return http.StatusText(e.StatusCode)
 	}

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -107,6 +107,16 @@ func (a *restAdapter) Post(ctxt context.Context, path string, body io.Reader, le
 	return Connect(ctxt, "POST", path, body, length, headers, &a.ctxt, nil, logger)
 }
 
+func (a *restAdapter) PostForm(ctxt context.Context, path string, data url.Values, headers *map[string]string, logger *log.Logger) (Payload, error) {
+	ed := data.Encode()
+	body := strings.NewReader(ed)
+	if headers == nil {
+		headers = &map[string]string{}
+	}
+	(*headers)["Content-Type"] = "application/x-www-form-urlencoded"
+	return Connect(ctxt, "POST", path, body, int64(len(ed)), headers, &a.ctxt, nil, logger)
+}
+
 func (a *restAdapter) Put(ctxt context.Context, path string, body io.Reader, length int64, headers *map[string]string, logger *log.Logger) (Payload, error) {
 	return Connect(ctxt, "PUT", path, body, length, headers, &a.ctxt, nil, logger)
 }

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -81,7 +81,7 @@ func (e *ApiError) Error() string {
 	if e.Payload != nil && !e.Payload.IsEmpty() {
 		return string(e.Payload.AsBytes())
 	} else {
-		return http.StatusText(e.StatusCode)
+		return fmt.Sprintf("%d: %s", e.StatusCode, http.StatusText(e.StatusCode))
 	}
 }
 

--- a/pkg/adapter/payload.go
+++ b/pkg/adapter/payload.go
@@ -185,6 +185,10 @@ func (p *payload) AsBytes() []byte {
 	return p.body
 }
 
+func (p *payload) IsEmpty() bool {
+	return p.body == nil || len(p.body) == 0
+}
+
 func (p *payload) Header(key string) string {
 	if p.headers != nil {
 		return p.headers.Get(key)

--- a/pkg/adapter/payload.go
+++ b/pkg/adapter/payload.go
@@ -35,7 +35,7 @@ type payload struct {
 	statusCode  int
 }
 
-func ToPayload(body []byte, resp *http.Response, logger *log.Logger) (Payload, error) {
+func ToPayload(body []byte, resp *http.Response, logger *log.Logger) Payload {
 	contentType := resp.Header.Get("Content-Type")
 	logger.Debug("Received", log.String("content-type", contentType))
 	return &payload{
@@ -43,7 +43,7 @@ func ToPayload(body []byte, resp *http.Response, logger *log.Logger) (Payload, e
 		contentType: contentType,
 		headers:     &resp.Header,
 		statusCode:  resp.StatusCode,
-	}, nil
+	}
 }
 
 func LoadPayloadFromStdin(isYAML bool) (Payload, error) {

--- a/pkg/adapter/types.go
+++ b/pkg/adapter/types.go
@@ -35,7 +35,6 @@ type Adapter interface {
 	Put(ctxt context.Context, path string, body io.Reader, length int64, headers *map[string]string, logger *log.Logger) (Payload, error)
 	Patch(ctxt context.Context, path string, body io.Reader, length int64, headers *map[string]string, logger *log.Logger) (Payload, error)
 	Delete(ctxt context.Context, path string, logger *log.Logger) (Payload, error)
-	ClearAuthorization() // no longer add authorization info to calls
 	SetUrl(url string)
 	GetPath(url string) (path string, err error)
 }

--- a/pkg/adapter/types.go
+++ b/pkg/adapter/types.go
@@ -45,6 +45,7 @@ type Payload interface {
 	AsObject() (map[string]interface{}, error)
 	AsArray() ([]interface{}, error)
 	AsBytes() []byte
+	IsEmpty() bool
 	Header(key string) string
 	StatusCode() int
 }

--- a/pkg/adapter/types.go
+++ b/pkg/adapter/types.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 
 	log "go.uber.org/zap"
 )
@@ -30,6 +31,7 @@ type Adapter interface {
 	Get(ctxt context.Context, path string, logger *log.Logger) (Payload, error)
 	Get2(ctxt context.Context, path string, headers *map[string]string, respHandler ResponseHandler, logger *log.Logger) error
 	Post(ctxt context.Context, path string, body io.Reader, length int64, headers *map[string]string, logger *log.Logger) (Payload, error)
+	PostForm(ctxt context.Context, path string, data url.Values, headers *map[string]string, logger *log.Logger) (Payload, error)
 	Put(ctxt context.Context, path string, body io.Reader, length int64, headers *map[string]string, logger *log.Logger) (Payload, error)
 	Patch(ctxt context.Context, path string, body io.Reader, length int64, headers *map[string]string, logger *log.Logger) (Payload, error)
 	Delete(ctxt context.Context, path string, logger *log.Logger) (Payload, error)


### PR DESCRIPTION
I'm sorry again for this major re-factoring, but I initially had some issue with my config file. That turned out
to be harder than I thought, so we better tell the early adopters to simply remove the current config file and start 
afresh. 

After chasing a subtle timing bug on login I  ended up moving all the direct HTTP request with functionality already provided by the Adapter API. This reduced the code size of login quite a bit. 

As we normally can't proceed when there is an error, I simply replace all those error returns with a call to corba..checkErr
which immediately stops the tool. This way quite a bit of additional code could be retired.

Also added a 'logout' command.

After all that, logging in via a QR code is REALLY cool.