### PR TITLE
artifact: If we can determine the file size on upload, use it

### DIFF
--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -158,13 +158,19 @@ var (
 				return
 			}
 			artifactID := *resp.ID
-			fmt.Printf("Created artifact '%s'\n", artifactID)
+			if !silent {
+				fmt.Printf("Created artifact '%s'\n", artifactID)
+			}
 			path, err := (*adapter).GetPath(*resp.Data.Self)
 			if err != nil {
 				cobra.CompErrorln(fmt.Sprintf("while parsing API reply - %v", err))
 				return
 			}
 			upload(ctxt, reader, artifactID, path, size, 0, adapter)
+			if silent {
+				fmt.Printf("%s\n", artifactID)
+			}
+
 		},
 	}
 
@@ -316,9 +322,10 @@ func upload(
 		cobra.CompErrorln(fmt.Sprintf("while uploading data file '%s' - %v", inputFile, err))
 		return
 	}
-	if !silent {
-		fmt.Printf("Completed uploading '%s'\n", artifactID)
+	if silent {
+		return
 	}
+	fmt.Printf("Completed uploading '%s'\n", artifactID)
 	readReq := &sdk.ReadArtifactRequest{Id: artifactID}
 
 	switch outputFormat {

--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -152,7 +152,7 @@ var (
 				Collection: artifactCollection,
 			}
 			ctxt := context.Background()
-			resp, err := sdk.CreateArtifact(ctxt, req, contentType, nil, adapter, logger)
+			resp, err := sdk.CreateArtifact(ctxt, req, contentType, size, nil, adapter, logger)
 			if err != nil {
 				cobra.CompErrorln(fmt.Sprintf("while creating record for '%s'- %v", inputFile, err))
 				return

--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -217,11 +217,13 @@ var (
 
 			if size > 0 && offset >= size {
 				// already done
-				fmt.Printf("Artifact '%s' already fully uploaded\n", artifactID)
+				cobra.CompErrorln(fmt.Sprintf("Artifact '%s' already fully uploaded\n", artifactID))
 				return
 			}
 
-			upload(ctxt, reader, artifactID, path, size, offset, adapter)
+			if err = upload(ctxt, reader, artifactID, path, size, offset, adapter); err != nil {
+				cobra.CompErrorln(fmt.Sprintf("while uploading artifact '%s' - %v", artifactID, err))
+			}
 		},
 	}
 

--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -403,7 +403,7 @@ func init() {
 	readArtifactCmd.Flags().StringVarP(&outputFormat, "output", "o", "short", "format to use for list (short, yaml, json)")
 
 	artifactCmd.AddCommand(downloadArtifactCmd)
-	downloadArtifactCmd.Flags().StringVarP(&outputFile, "output", "o", "", "File to write content to [stdout]")
+	downloadArtifactCmd.Flags().StringVarP(&outputFile, "file", "f", "", "File to write content to [stdout]")
 
 	artifactCmd.AddCommand(createArtifactCmd)
 	createArtifactCmd.Flags().StringVarP(&artifactName, "name", "n", "", "Human friendly name")
@@ -423,7 +423,7 @@ func init() {
 	artifactCmd.AddCommand(removeArtifactFromCollectionCmd)
 
 	artifactCmd.AddCommand(addArtifactMetadataCmd)
-	addArtifactMetadataCmd.Flags().StringVarP(&metaFile, "file", "f", "", "Path to file containing metdata")
+	addArtifactMetadataCmd.Flags().StringVarP(&metaFile, "file", "f", "", "Path to file containing metadata")
 	artifactCmd.AddCommand(removeArtifactMetadataCmd)
 }
 

--- a/cmd/metadata.go
+++ b/cmd/metadata.go
@@ -66,7 +66,15 @@ var (
 			logger.Debug("add meta", log.String("entity", entity), log.String("schema", schema), log.Reflect("pyld", meta))
 			ctxt := context.Background()
 			if res, err := sdk.AddMetadata(ctxt, entity, schema, pyld.AsBytes(), CreateAdapter(true), logger); err == nil {
-				a.ReplyPrinter(res, outputFormat == "yaml")
+				if silent {
+					if m, err := res.AsObject(); err == nil {
+						fmt.Printf("%s\n", m["record-id"])
+					} else {
+						cobra.CheckErr(fmt.Sprintf("Parsing reply: %s", res.AsBytes()))
+					}
+				} else {
+					a.ReplyPrinter(res, outputFormat == "yaml")
+				}
 			} else {
 				return err
 			}

--- a/pkg/artifact.go
+++ b/pkg/artifact.go
@@ -82,11 +82,12 @@ func CreateArtifact(
 	ctxt context.Context,
 	cmd *CreateArtifactRequest,
 	contentType string,
+	size int64,
 	reader io.Reader,
 	adpt *adapter.Adapter,
 	logger *log.Logger,
 ) (*api.UploadResponseBody, error) {
-	if res, err := CreateArtifactRaw(ctxt, cmd, contentType, reader, adpt, logger); err == nil {
+	if res, err := CreateArtifactRaw(ctxt, cmd, contentType, size, reader, adpt, logger); err == nil {
 		var artifact api.UploadResponseBody
 		if err := res.AsType(&artifact); err != nil {
 			return nil, err
@@ -235,6 +236,7 @@ func CreateArtifactRaw(
 	ctxt context.Context,
 	cmd *CreateArtifactRequest,
 	contentType string,
+	size int64,
 	reader io.Reader,
 	adpt *adapter.Adapter,
 	logger *log.Logger,
@@ -245,9 +247,13 @@ func CreateArtifactRaw(
 	if reader != nil {
 		headers["Upload-Length"] = fmt.Sprintf("%d", cmd.Size)
 		headers["Tus-Resumable"] = "1.0.0"
+		if size > 0 {
+			headers["Upload-Length"] = fmt.Sprintf("%d", size)
+		}
 		headers["Content-Type"] = contentType
 	} else {
 		headers["X-Content-Type"] = contentType
+		headers["X-Content-Length"] = fmt.Sprintf("%d", size)
 		contentLength = 0
 	}
 	if cmd.Name != "" {


### PR DESCRIPTION

TUS expects the overall file size to be provided via `Upload-Length`.
If we create an artifact 'placeholder' by not including any payload on `POST`
and if we know the file size, report it via `X-Content-Length`.